### PR TITLE
Improve input handling and speed up install script

### DIFF
--- a/scripts/install_inzight.sh
+++ b/scripts/install_inzight.sh
@@ -1,9 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 
 echo -n "Where do you want to install iNZightVIT? (default ~): "
 read dir
 dir=${dir:=~}
+dir=${dir/#\~/$HOME}
+
 echo Installing to $dir/iNZightVIT
 
 inst_dir=$dir/iNZightVIT
@@ -18,13 +20,14 @@ options(repos = c("http://r.docker.stat.auckland.ac.nz/R",
 
 EOF
 
+cpu_count=$(getconf _NPROCESSORS_ONLN)
 
 echo "Installing iNZight packages ..."
 cd $inst_dir && R --slave -e \
   "install.packages(c('iNZightRegression', 'iNZightPlots', \
                       'iNZightTS', 'iNZightMR', 'vit', 'iNZightTools', \
                       'FutureLearnData', 'iNZightModules', 'iNZight'), \
-                    dependencies = TRUE)"
+                    dependencies = TRUE, Ncpus=$cpu_count)"
 
 echo "Creating additional files ..."
 cat << EOF >> $inst_dir/.Rprofile


### PR DESCRIPTION
This is just a quick fix for some issues I had with the linux install script.

As it was, ~ was not accepted in the install directory prompt, (since it was given as the default I used it out of habit). The only reasonable way I know of dealing with this required changing to #!/bin/bash, feel free to ignore me if #!/bin/sh was required by anything.

Installing packages from source was only running on one core by default, I've changed it to use the number of available logical cores to speed things up slightly. Curiously it looks like make is still run with -j1, but R now installs multiple packages simultaneously, which is good enough for me.

It also looks like I needed libgtk2.0-dev and libiodbc2-dev to install on Ubuntu 16.04, not sure if this is mentioned anywhere.

Tested on Ubuntu 16.04.1